### PR TITLE
Detect Colons Again

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var postcss = require('postcss');
 module.exports = postcss.plugin('postcss-short-data', function () {
 	return function (css) {
 		css.walkRules(function (rule) {
-			rule.selector = rule.selector.replace(/\[-([^\]])/, '[data-$1');
+			rule.selector = rule.selector.replace(/\[\:([^\]])/, '[data-$1');
 		});
 	};
 });


### PR DESCRIPTION
The current regex `/\[-([^\]])/` detects dashes as the trigger for making the `data-` attribute. I made it a colon again so it works as expected.
